### PR TITLE
fix: Corrects links to spicy terms

### DIFF
--- a/pages/other-terms.mdx
+++ b/pages/other-terms.mdx
@@ -16,11 +16,11 @@ The data that a [rollup](#rollup) publishes to its [L1](#layer-1)/[data availabi
 
 ## Blobspace
 
-The storage area within Ethereum’s Beacon [nodes](#node) where [blobs](#blobs) are published by [rollups](/foundational-terms#rollup) and ephemerally stored.
+The storage area within Ethereum’s Beacon [nodes](#node) where [blobs](#blobs) are published by [rollups](/spicy-terms#rollup) and ephemerally stored.
 
 ## Block
 
-An ordered list of [transactions](#Transaction) and chain-related metadata that gets bundled together and published to the [L1](#Layer-1)/[DA](/foundational-terms#Data-availability) layer. [Nodes](#node) execute the transactions contained within blocks to change the [rollup](/foundational-terms#Rollup) chain’s state. Protocol rules dictate what constitutes a valid block, and invalid blocks are skipped over.
+An ordered list of [transactions](#Transaction) and chain-related metadata that gets bundled together and published to the [L1](#Layer-1)/[DA](/spicy-terms#Data-availability) layer. [Nodes](#node) execute the transactions contained within blocks to change the [rollup](/spicy-terms#Rollup) chain’s state. Protocol rules dictate what constitutes a valid block, and invalid blocks are skipped over.
 
 ## Bridge
 
@@ -32,7 +32,7 @@ A type of zero-knowledge proof that enables efficient range proofs and other mat
 
 ## Bytecode
 
-Generally, an instruction set designed for efficient execution by a software interpreter or a virtual machine. Unlike human-readable source code, bytecode is expressed numerically. Within the context of [rollups](/foundational-terms#Rollup), often related to the concept of [compatibility](#compatibility): whether the bytecode of programs on the rollup are capable of being run as-is on Ethereum as well, and vice versa.
+Generally, an instruction set designed for efficient execution by a software interpreter or a virtual machine. Unlike human-readable source code, bytecode is expressed numerically. Within the context of [rollups](/spicy-terms#Rollup), often related to the concept of [compatibility](#compatibility): whether the bytecode of programs on the rollup are capable of being run as-is on Ethereum as well, and vice versa.
 
 ## Challenge period
 
@@ -44,7 +44,7 @@ A program written for the purposes of being [proven](#Prover) within a proving s
 
 ## Client
 
-Sometimes labelled interchangeably as a “[node](#node)”, they are tasked with processing [transactions](#Transaction) and managing the [rollup](/foundational-terms#Rollup)’s state. They run the computations for each transaction according to the rollup’s virtual machine and protocol rules. If comparing to Ethereum clients, these would be execution clients such as [Geth](#Geth), as opposed to [consensus](#Consensus) clients.
+Sometimes labelled interchangeably as a “[node](#node)”, they are tasked with processing [transactions](#Transaction) and managing the [rollup](/spicy-terms#Rollup)’s state. They run the computations for each transaction according to the rollup’s virtual machine and protocol rules. If comparing to Ethereum clients, these would be execution clients such as [Geth](#Geth), as opposed to [consensus](#Consensus) clients.
 
 ## Consensus
 
@@ -52,7 +52,7 @@ An agreement on the latest and correct state of a blockchain. Unlike [L1](#layer
 
 ## Compatibility
 
-The degree to which a [rollup](/foundational-terms#Rollup) can make use of existing patterns, code, and tooling from another blockchain or development environment. Today, this typically refers to how well rollups and developers thereon can make use of the [Ethereum Virtual Machine](#Ethereum-Virtual-Machine-(EVM)), existing [smart contracts](#Smart-contract), and other Ethereum infrastructure.
+The degree to which a [rollup](/spicy-terms#Rollup) can make use of existing patterns, code, and tooling from another blockchain or development environment. Today, this typically refers to how well rollups and developers thereon can make use of the [Ethereum Virtual Machine](#Ethereum-Virtual-Machine-(EVM)), existing [smart contracts](#Smart-contract), and other Ethereum infrastructure.
 
 ## Commitment Scheme
 
@@ -65,16 +65,16 @@ One of three properties of [zero-knowledge proofs](#zero-knowledge-proof), compl
 
 ## Danksharding
 
-A sharding design proposed for Ethereum. Instead of providing more space for transactions, Ethereum sharding provides more space for [blobs](#blobs) of data. Verifying a blob simply requires checking that the blob is available - that it can be downloaded from the [network](#Network). The data space in these blobs is expected to be used by [layer-2](/foundational-terms#Layer-2) rollup protocols.
+A sharding design proposed for Ethereum. Instead of providing more space for transactions, Ethereum sharding provides more space for [blobs](#blobs) of data. Verifying a blob simply requires checking that the blob is available - that it can be downloaded from the [network](#Network). The data space in these blobs is expected to be used by [layer-2](/spicy-terms#Layer-2) rollup protocols.
 In comparison to other sharding mechanisms, where there are a fixed number of shards with distinct [blocks](#Block) and distinct block [proposers](#Proposer), in Danksharding there is only one proposer that chooses all transactions and all data that go into that slot.
 
 ## Determinism
 
-The concept of some function or process having a single outcome that is knowable by all participants. In the context of a [rollup](/foundational-terms#Rollup), it generally refers to the new state being calculable given a prior state and a list of [transactions](#Transaction) to be executed.
+The concept of some function or process having a single outcome that is knowable by all participants. In the context of a [rollup](/spicy-terms#Rollup), it generally refers to the new state being calculable given a prior state and a list of [transactions](#Transaction) to be executed.
 
 ## Ethereum Virtual Machine (EVM)
 
-A stack-based virtual machine that executes [bytecode](#bytecode). In Ethereum, the execution model specifies how the system state is altered given a series of bytecode instructions and a small tuple of environmental data. In the context of [rollups](/foundational-terms#Rollup), the EVM is a choice of execution environment that rollups could implement, as in the case of EVM ZK-Rollups ([ZK-EVMs](#ZK-EVM)) and EVM [optimistic rollups](#optimistic-rollup).
+A stack-based virtual machine that executes [bytecode](#bytecode). In Ethereum, the execution model specifies how the system state is altered given a series of bytecode instructions and a small tuple of environmental data. In the context of [rollups](/spicy-terms#Rollup), the EVM is a choice of execution environment that rollups could implement, as in the case of EVM ZK-Rollups ([ZK-EVMs](#ZK-EVM)) and EVM [optimistic rollups](#optimistic-rollup).
 
 ## Execution environment
 
@@ -82,11 +82,11 @@ Refers to both the environment where transactions are processed, constituted by 
 
 ## Equivalence
 
-A perfect degree of [compatibility](#compatibility); where one system or concept is indistinguishable from another in the domain being compared. In the context of [rollups](/foundational-terms#Rollup), it generally refers to the proximity to the [EVM](#Ethereum-Virtual-Machine-(EVM)) and to Ethereum architecture.
+A perfect degree of [compatibility](#compatibility); where one system or concept is indistinguishable from another in the domain being compared. In the context of [rollups](/spicy-terms#Rollup), it generally refers to the proximity to the [EVM](#Ethereum-Virtual-Machine-(EVM)) and to Ethereum architecture.
 
 ## Escape hatch
 
-The facility for any user of a [rollup](/foundational-terms#Rollup) to exit the system with their assets under any circumstance. Most relevant in rollups with a centralized [proposer](#proposer), wherein users do not have the ability to propose [blocks](#Block), but can nonetheless exit the rollup by interacting with a [smart contract](#Smart-contract) on [L1](#Layer-1).
+The facility for any user of a [rollup](/spicy-terms#Rollup) to exit the system with their assets under any circumstance. Most relevant in rollups with a centralized [proposer](#proposer), wherein users do not have the ability to propose [blocks](#Block), but can nonetheless exit the rollup by interacting with a [smart contract](#Smart-contract) on [L1](#Layer-1).
 
 ## Fast Fourier Transform (FFT)
 
@@ -155,7 +155,7 @@ A formula that helps to find a polynomial which takes on certain values at arbit
 
 ## Layer 1
 
-Layer 1 (L1) is a blockchain that is self-reliant on its [validator](#Validator) set for its security and [consensus](#consensus) properties. Ethereum is an example of a layer 1. Blockchains started receiving the moniker of layer 1 once [layer 2](/foundational-terms#Layer-2) became a meaningful area of development.
+Layer 1 (L1) is a blockchain that is self-reliant on its [validator](#Validator) set for its security and [consensus](#consensus) properties. Ethereum is an example of a layer 1. Blockchains started receiving the moniker of layer 1 once [layer 2](/spicy-terms#Layer-2) became a meaningful area of development.
 
 ## Lookup table
 
@@ -167,7 +167,7 @@ The maximum profit that can be extracted from block production by including, exc
 
 ## Merkle proofs
 
-[Hashing](#Hash) the pairs of values at each layer (hashing hashes starting from [layer 2](/foundational-terms#Layer-2)) and climbing up the (Merkle) Tree until you obtain the root hash. Merkle proofs help check if the data belongs to a set without having to store the set.
+[Hashing](#Hash) the pairs of values at each layer (hashing hashes starting from [layer 2](/spicy-terms#Layer-2)) and climbing up the (Merkle) Tree until you obtain the root hash. Merkle proofs help check if the data belongs to a set without having to store the set.
 
 ## Merkle tree
 
@@ -175,11 +175,11 @@ A hash-based data structure in which each leaf [node](#node) is a [hash](#hash) 
 
 ## Modular blockchains
 
-A blockchain that fully outsources at least one of the 4 components ([Consensus](#Consensus), [Data Availability](/spicy-terms#data-availability), Execution, [Settlement](#Settlement)) to an external chain. For example, [rollup](/foundational-terms#Rollup) is a modular blockchain as it handles [transaction](#Transaction) executions off-chain and ‘outsources’ data availability and consensus to Ethereum.
+A blockchain that fully outsources at least one of the 4 components ([Consensus](#Consensus), [Data Availability](/spicy-terms#data-availability), Execution, [Settlement](#Settlement)) to an external chain. For example, [rollup](/spicy-terms#Rollup) is a modular blockchain as it handles [transaction](#Transaction) executions off-chain and ‘outsources’ data availability and consensus to Ethereum.
 
 ## Multi-proof system
 
-A [rollup](/foundational-terms#Rollup) [settlement](#settlement) concept that relies on a combination of multiple different proving systems. For example, a combination of [fraud proof](#Fraud-proof) and [validity proof](#Validity-proof). The goal is to reduce reliance on a single system-type or implementation. A more complex example of a multi-proof system: if anyone submits two conflicting state roots to a [prover](#Prover) and both roots pass, that prover is turned off.
+A [rollup](/spicy-terms#Rollup) [settlement](#settlement) concept that relies on a combination of multiple different proving systems. For example, a combination of [fraud proof](#Fraud-proof) and [validity proof](#Validity-proof). The goal is to reduce reliance on a single system-type or implementation. A more complex example of a multi-proof system: if anyone submits two conflicting state roots to a [prover](#Prover) and both roots pass, that prover is turned off.
 
 ## Multi-scalar multiplication (MSM)
 
@@ -203,11 +203,11 @@ A type of encryption that uses a random key that is only used once to encrypt a 
 
 ## Operator
 
-An operator is the entity charged with managing a [rollup](/foundational-terms#Rollup) and progressing its state. While similar to the concept of a [proposer](#Proposer), operator is often meant to convey a centralized rollup implementation, with a single operator acting as [node](#Node), proposer (and prover if [ZK](#Zero-knowledge)).
+An operator is the entity charged with managing a [rollup](/spicy-terms#Rollup) and progressing its state. While similar to the concept of a [proposer](#Proposer), operator is often meant to convey a centralized rollup implementation, with a single operator acting as [node](#Node), proposer (and prover if [ZK](#Zero-knowledge)).
 
 ## Optimistic rollup
 
-A [rollup](/foundational-terms#Rollup) that optimistically updates state with the possibility of [fraud proofs](#Fraud-proof) being generated to revert faulty state transitions. Optimistic rollups have primarily been [EVM-compatible](/foundational-terms#Bytecode-compatible-(EVM-compatible)-ZK-EVM) to date. Compared to [ZK-Rollups](#ZK-Rollup), they have longer time to [finality](/foundational-terms#Finality) as there is a time window ([challenge period](#Challenge-period)) during which anyone can challenge the results of a rollup transaction by computing a fraud proof.
+A [rollup](/spicy-terms#Rollup) that optimistically updates state with the possibility of [fraud proofs](#Fraud-proof) being generated to revert faulty state transitions. Optimistic rollups have primarily been [EVM-compatible](/spicy-terms#Bytecode-compatible-(EVM-compatible)-ZK-EVM) to date. Compared to [ZK-Rollups](#ZK-Rollup), they have longer time to [finality](/spicy-terms#Finality) as there is a time window ([challenge period](#Challenge-period)) during which anyone can challenge the results of a rollup transaction by computing a fraud proof.
 
 ## PLONK
 
@@ -241,15 +241,15 @@ A theoretical cryptographic primitive that is used to model the behavior of hash
 
 ## Rewards
 
-In the context of a [rollup](/foundational-terms#rollup), an amount of some token allotted as a reward to the participant—[proposer](#Proposer) and/or [prover](#Prover)—who performed a service for the [network](#network).
+In the context of a [rollup](/spicy-terms#rollup), an amount of some token allotted as a reward to the participant—[proposer](#Proposer) and/or [prover](#Prover)—who performed a service for the [network](#network).
 
 ## Rollup-as-a-service
 
-An SDK or service that allows anyone to launch [rollups](/foundational-terms#rollup) quickly. Emphasis may be placed on the ability to customize the [modular](#Modular-blockchain) components of a rollup: VM, [DA](/foundational-terms#Data-availability) layer, proof system.
+An SDK or service that allows anyone to launch [rollups](/spicy-terms#rollup) quickly. Emphasis may be placed on the ability to customize the [modular](#Modular-blockchain) components of a rollup: VM, [DA](/spicy-terms#Data-availability) layer, proof system.
 
 ## Rollup contracts
 
-A bundle of [smart contracts](#Smart-contract) running on Ethereum that controls a [rollup](/foundational-terms#rollup) protocol. It includes the main contract which stores rollup [blocks](#block), tracks deposits, and monitors state updates, and the [verifier](#verifier) contract which verifies [zero-knowledge proofs](#Zero-knowledge-proof-(ZKP)) submitted by [provers](#Prover).
+A bundle of [smart contracts](#Smart-contract) running on Ethereum that controls a [rollup](/spicy-terms#rollup) protocol. It includes the main contract which stores rollup [blocks](#block), tracks deposits, and monitors state updates, and the [verifier](#verifier) contract which verifies [zero-knowledge proofs](#Zero-knowledge-proof-(ZKP)) submitted by [provers](#Prover).
 
 ## RPC (Remote Procedure Call)
 
@@ -261,11 +261,11 @@ A type of computation where multiple parties jointly compute a function without 
 
 ## Sequencer
 
-A party responsible for ordering and executing [transactions](#Transaction) on the [rollup](/foundational-terms#Rollup). The sequencer [verifies](#Verifier) transactions, compresses the data into a [block](#block), and submits the batch to Ethereum [L1](#Layer-1) as a single transaction. Often synonymous with [proposer](#proposer).
+A party responsible for ordering and executing [transactions](#Transaction) on the [rollup](/spicy-terms#Rollup). The sequencer [verifies](#Verifier) transactions, compresses the data into a [block](#block), and submits the batch to Ethereum [L1](#Layer-1) as a single transaction. Often synonymous with [proposer](#proposer).
 
 ## Settlement
 
-The mechanism with which the execution of [rollup](/foundational-terms#Rollup) [blocks](#Block) and the resultant state is [verified](#Verifier) and possible disputes are resolved. In the context of rollups or other [modular blockchains](#Modular-blockchains), it often refers to the proof system used--[validity (ZK)](#Validity-Proof) or [fraud proofs](#Fraud-proof), or a combination thereof. Sometimes it will refer to this mechanism along with where the mechanism's outputs are ultimately published and verified, as in Ethereum being a settlement layer by verifying the proof(s).
+The mechanism with which the execution of [rollup](/spicy-terms#Rollup) [blocks](#Block) and the resultant state is [verified](#Verifier) and possible disputes are resolved. In the context of rollups or other [modular blockchains](#Modular-blockchains), it often refers to the proof system used--[validity (ZK)](#Validity-Proof) or [fraud proofs](#Fraud-proof), or a combination thereof. Sometimes it will refer to this mechanism along with where the mechanism's outputs are ultimately published and verified, as in Ethereum being a settlement layer by verifying the proof(s).
 
 ## Schnorr signature
 
@@ -281,7 +281,7 @@ Short for "[succinct](#Succinctness) non-interactive argument of knowledge", a S
 
 ## STARK
 
-Short for "[scalable](/foundational-terms#Scalability) transparent argument of knowledge", a STARK is a type of [zero-knowledge proof](#Zero-knowledge-proof-(ZKP)) that resolves one of the primary weaknesses of ZK-[SNARKs](#SNARK), its reliance on a "[trusted setup](#Trusted-setup)”. STARKs also come with much simpler cryptographic assumptions, avoiding the need for elliptic curves, pairings, and the knowledge-of-exponent assumption and instead relying purely on [hashes](#Hash) and information theory. This means that they are secure even against attackers with quantum computers.
+Short for "[scalable](/spicy-terms#Scalability) transparent argument of knowledge", a STARK is a type of [zero-knowledge proof](#Zero-knowledge-proof-(ZKP)) that resolves one of the primary weaknesses of ZK-[SNARKs](#SNARK), its reliance on a "[trusted setup](#Trusted-setup)”. STARKs also come with much simpler cryptographic assumptions, avoiding the need for elliptic curves, pairings, and the knowledge-of-exponent assumption and instead relying purely on [hashes](#Hash) and information theory. This means that they are secure even against attackers with quantum computers.
 
 ## Succinctness
 
@@ -289,7 +289,7 @@ A property of [ZKP](#Zero-knowledge-proof-(ZKP)) that stands for the following t
 
 ## Time Delay
 
-In regards to [upgradeability](/foundational-terms#Upgradeability), a predefined amount of time that must elapse before the [rollup](/foundational-terms#Rollup) [smart contracts](#Smart-contract) or parameters are updated. This protects users from malicious upgrades by giving them time to exit the rollup before upgrades come into effect.
+In regards to [upgradeability](/spicy-terms#Upgradeability), a predefined amount of time that must elapse before the [rollup](/spicy-terms#Rollup) [smart contracts](#Smart-contract) or parameters are updated. This protects users from malicious upgrades by giving them time to exit the rollup before upgrades come into effect.
 
 ## Transaction
 
@@ -318,7 +318,7 @@ A [node](#node) in a blockchain system responsible for processing transactions, 
 
 ## Validity proof
 
-The output of a cryptographic proving system attesting to correct computation. [ZK-Rollups](#ZK-Rollup) use [succinct](#Succinctness) validity proofs (also called [zero-knowledge proofs](#Zero-knowledge-proof-(ZKP))) to [prove](#Prover) a batch of [rollup](/foundational-terms#rollup) [transactions](#Transaction) and [blocks](#Block) were properly executed. Validity proofs are submitted to a [verifier](#Verifier), such as an Ethereum [smart contract](#Smart-contract), which accepts them if properly constructed.
+The output of a cryptographic proving system attesting to correct computation. [ZK-Rollups](#ZK-Rollup) use [succinct](#Succinctness) validity proofs (also called [zero-knowledge proofs](#Zero-knowledge-proof-(ZKP))) to [prove](#Prover) a batch of [rollup](/spicy-terms#rollup) [transactions](#Transaction) and [blocks](#Block) were properly executed. Validity proofs are submitted to a [verifier](#Verifier), such as an Ethereum [smart contract](#Smart-contract), which accepts them if properly constructed.
 
 ## Validium
 
@@ -346,4 +346,4 @@ A zero-knowledge proof is the resulting output of a [zero-knowledge](#Zero-knowl
 
 ## ZK-Rollup
 
-A [rollup](/foundational-terms#rollup) that uses [ZKPs](#Zero-knowledge-proof-(ZKP)) (also often called [validity proofs](#Validity-proof) to [validate](#Validator) the correctness of the state transition function and update the rollup state. This is one of two main types of rollup constructions, along with [optimistic rollups](#Optimistic-rollup). In general, ZK-Rollups do not provide privacy preserving properties; privacy preserving ZK-Rollups are sometimes called ZK-ZK-Rollups.
+A [rollup](/spicy-terms#rollup) that uses [ZKPs](#Zero-knowledge-proof-(ZKP)) (also often called [validity proofs](#Validity-proof) to [validate](#Validator) the correctness of the state transition function and update the rollup state. This is one of two main types of rollup constructions, along with [optimistic rollups](#Optimistic-rollup). In general, ZK-Rollups do not provide privacy preserving properties; privacy preserving ZK-Rollups are sometimes called ZK-ZK-Rollups.


### PR DESCRIPTION
Page was likely renamed from foundational terms to spice terms

Currently they are dead links