### PR TITLE
docs: update vitalik blog link

### DIFF
--- a/pages/spicy-terms.mdx
+++ b/pages/spicy-terms.mdx
@@ -1,7 +1,7 @@
 
 ## Bytecode-equivalent ZK-EVM
 
-A [ZK-Rollup](/other-terms#zk-rollup) that can interpret and execute [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) [bytecode](/other-terms#bytecode). All EVM opcodes and pre-compiles are supported and provable through the [ZK-EVM](/other-terms#zk-evm) [circuit](/other-terms#circuit), but gas costs for EVM opcodes might be changed. (Type 2.5 in [Vitalik's classification](https://vitalik.ca/general/2022/08/04/zkevm.html)).
+A [ZK-Rollup](/other-terms#zk-rollup) that can interpret and execute [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) [bytecode](/other-terms#bytecode). All EVM opcodes and pre-compiles are supported and provable through the [ZK-EVM](/other-terms#zk-evm) [circuit](/other-terms#circuit), but gas costs for EVM opcodes might be changed. (Type 2.5 in [Vitalik's classification](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)).
 
 ## Data availability
 
@@ -13,15 +13,15 @@ There are several factors within a [rollup](#rollup) construction which separate
 
 ## Ethereum-equivalent ZK-EVM
 
-A [ZK-Rollup](/other-terms#ZK-Rollup) that can [prove](/other-terms#Prover) the correctness of an actual Ethereum [L1](/other-terms#Layer-1) [block](/other-terms#Block) in its [ZK-EVM](#ZK-EVM) [circuit](/other-terms#circuit). No changes made to any part of Ethereum--EVM but also peripheral things like storage structures and hash functions. (Type 1 in [Vitalik's classification](https://vitalik.ca/general/2022/08/04/zkevm.html)).
+A [ZK-Rollup](/other-terms#ZK-Rollup) that can [prove](/other-terms#Prover) the correctness of an actual Ethereum [L1](/other-terms#Layer-1) [block](/other-terms#Block) in its [ZK-EVM](#ZK-EVM) [circuit](/other-terms#circuit). No changes made to any part of Ethereum--EVM but also peripheral things like storage structures and hash functions. (Type 1 in [Vitalik's classification](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)).
 
 ## EVM-equivalent ZK-EVM
 
-A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) [bytecode](/other-terms#Bytecode). All EVM opcodes and [pre-compiles](/other-terms#Pre-compiles) are supported and provable through the [ZK-EVM])(#ZK-EVM) [circuit](/other-terms#circuit). (Type 2 in [Vitalik's classification](https://vitalik.ca/general/2022/08/04/zkevm.html)).
+A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) [bytecode](/other-terms#Bytecode). All EVM opcodes and [pre-compiles](/other-terms#Pre-compiles) are supported and provable through the [ZK-EVM])(#ZK-EVM) [circuit](/other-terms#circuit). (Type 2 in [Vitalik's classification](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)).
 
 ## Bytecode-compatible (EVM-compatible) ZK-EVM
 
-A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute Ethereum [bytecode](/other-terms#Bytecode), with some changes made to certain components of the [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)), such as different gas costs, or some unsupported features. (Type 2.5 and 3 in [Vitalik's classification](https://vitalik.ca/general/2022/08/04/zkevm.html)).
+A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute Ethereum [bytecode](/other-terms#Bytecode), with some changes made to certain components of the [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)), such as different gas costs, or some unsupported features. (Type 2.5 and 3 in [Vitalik's classification](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)).
 
 ## Finality
 
@@ -31,7 +31,7 @@ Finality is a scale--when a valid [L2](#Layer-2) [transaction](/other-terms#Tran
 
 ## Language-compatible ZK-EVM
 
-A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute Solidity or other high-level-language source code. This code is compiled into [bytecode](/other-terms#Bytecode) that differs from that which the [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) runs. (Type 4 in [Vitalik's classification](https://vitalik.ca/general/2022/08/04/zkevm.html)).
+A [ZK-Rollup](/other-terms#ZK-Rollup) that can interpret and execute Solidity or other high-level-language source code. This code is compiled into [bytecode](/other-terms#Bytecode) that differs from that which the [EVM](/other-terms#Ethereum-Virtual-Machine-(EVM)) runs. (Type 4 in [Vitalik's classification](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)).
 
 ## Layer 2
 


### PR DESCRIPTION
update vitalik blog link to `vitalik.eth.limo` since the old one `vitalik.ca` is not working anymore.